### PR TITLE
OAK-11525 Update fullGC configuration for audit logging into Mongo collection

### DIFF
--- a/oak-run/src/main/java/org/apache/jackrabbit/oak/run/RevisionsCommand.java
+++ b/oak-run/src/main/java/org/apache/jackrabbit/oak/run/RevisionsCommand.java
@@ -134,6 +134,7 @@ public class RevisionsCommand implements Command {
         final OptionSpec<Boolean> dryRun;
         final OptionSpec<Boolean> embeddedVerification;
         final OptionSpec<Integer> fullGcMode;
+        final OptionSpec<Boolean> fullGCAuditLoggingEnabled;
 
         RevisionsOptions(String usage) {
             super(usage);
@@ -195,6 +196,8 @@ public class RevisionsCommand implements Command {
                             "to be considered for Full GC i.e. Version Garbage Collector (Full GC) logic will only consider those " +
                             "nodes for Full GC which are not accessed recently (currentTime - lastModifiedTime > fullGcMaxAge). Default: 86400 (one day)")
                     .withOptionalArg().ofType(Long.class).defaultsTo(TimeUnit.DAYS.toSeconds(1));
+            fullGCAuditLoggingEnabled = parser.accepts("fullGCAuditLoggingEnabled", "Enable audit logging for Full GC")
+                    .withOptionalArg().ofType(Boolean.class).defaultsTo(FALSE);
         }
 
         public RevisionsOptions parse(String[] args) {
@@ -293,6 +296,10 @@ public class RevisionsCommand implements Command {
         boolean doCompaction() {
             return options.has(compact);
         }
+
+        Boolean isFullGCAuditLoggingEnabled() {
+            return options.has(fullGCAuditLoggingEnabled);
+        }
     }
 
     @Override
@@ -358,6 +365,7 @@ public class RevisionsCommand implements Command {
         builder.setFullGCBatchSize(options.getFullGcBatchSize());
         builder.setFullGCProgressSize(options.getFullGcProgressSize());
         builder.setFullGcMaxAgeMillis(SECONDS.toMillis(options.getFullGcMaxAge()));
+        builder.setFullGCAuditLoggingEnabled(options.isFullGCAuditLoggingEnabled());
 
         // create a VersionGCSupport while builder is read-write
         VersionGCSupport gcSupport = builder.createVersionGCSupport();
@@ -391,6 +399,7 @@ public class RevisionsCommand implements Command {
         System.out.println("FullGcProgressSize is : " + options.getFullGcProgressSize());
         System.out.println("FullGcMaxAgeInSecs is : " + options.getFullGcMaxAge());
         System.out.println("FullGcMaxAgeMillis is : " + builder.getFullGcMaxAgeMillis());
+        System.out.println("FullGCAuditLoggingEnabled is : " + options.isFullGCAuditLoggingEnabled());
         VersionGarbageCollector gc = createVersionGC(builder.build(), gcSupport, options.isDryRun(), builder);
 
         VersionGCOptions gcOptions = gc.getOptions();

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/Configuration.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/Configuration.java
@@ -400,4 +400,9 @@ import static org.apache.jackrabbit.oak.plugins.document.DocumentNodeStoreServic
             name = "Invisible for discovery",
             description = "Boolean value indicating whether the instance should be discoverable by the cluster. The default value is " + DocumentNodeStoreService.DEFAULT_INVISIBLE_FOR_DISCOVERY)
     boolean invisibleForDiscovery() default DocumentNodeStoreService.DEFAULT_INVISIBLE_FOR_DISCOVERY;
+
+    @AttributeDefinition(
+        name = "Enable Full GC Persistent Audit Logging",
+        description = "This parameter will enable/disable the saving of deleted document IDs and properties during FullGC into a persistent storage, e.g Mongo collection")
+    boolean fullGCAuditLoggingEnabled() default false;
 }

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreBuilder.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreBuilder.java
@@ -185,6 +185,7 @@ public class DocumentNodeStoreBuilder<T extends DocumentNodeStoreBuilder<T>> {
     private int fullGCBatchSize = DocumentNodeStoreService.DEFAULT_FGC_BATCH_SIZE;
     private int fullGCProgressSize = DocumentNodeStoreService.DEFAULT_FGC_PROGRESS_SIZE;
     private double fullGCDelayFactor = DocumentNodeStoreService.DEFAULT_FGC_DELAY_FACTOR;
+    private boolean fullGCAuditLoggingEnabled;
     private long suspendTimeoutMillis = DEFAULT_SUSPEND_TIMEOUT;
 
     /**
@@ -315,6 +316,15 @@ public class DocumentNodeStoreBuilder<T extends DocumentNodeStoreBuilder<T>> {
 
     public boolean isFullGCEnabled() {
         return this.fullGCEnabled;
+    }
+
+    public T setFullGCAuditLoggingEnabled(boolean b) {
+        this.fullGCAuditLoggingEnabled = b;
+        return thisBuilder();
+    }
+
+    public boolean isFullGCAuditLoggingEnabled() {
+        return this.fullGCAuditLoggingEnabled;
     }
 
     public T setFullGCIncludePaths(@Nullable String[] includePaths) {

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreService.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreService.java
@@ -534,6 +534,7 @@ public class DocumentNodeStoreService {
                 setFullGCBatchSize(config.fullGCBatchSize()).
                 setFullGCProgressSize(config.fullGCProgressSize()).
                 setFullGCDelayFactor(config.fullGCDelayFactor()).
+                setFullGCAuditLoggingEnabled(config.fullGCAuditLoggingEnabled()).
                 setSuspendTimeoutMillis(config.suspendTimeoutMillis()).
                 setClusterIdReuseDelayAfterRecovery(config.clusterIdReuseDelayAfterRecoveryMillis()).
                 setRecoveryDelayMillis(config.recoveryDelayMillis()).

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/FullGcNodeBin.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/FullGcNodeBin.java
@@ -31,6 +31,8 @@ import java.util.Map;
  */
 public interface FullGcNodeBin {
 
+    String OAK_DOCUMENT_FULL_GC_BIN_ENABLED = "oak.document.fullGcBin.enabled";
+
     static FullGcNodeBin noBin(DocumentStore store) {
         return new FullGcNodeBin() {
             @Override

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/FullGcNodeBin.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/FullGcNodeBin.java
@@ -31,8 +31,6 @@ import java.util.Map;
  */
 public interface FullGcNodeBin {
 
-    String OAK_DOCUMENT_FULL_GC_BIN_ENABLED = "oak.documentstore.fullGCAuditLoggingEnabled";
-
     static FullGcNodeBin noBin(DocumentStore store) {
         return new FullGcNodeBin() {
             @Override

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/FullGcNodeBin.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/FullGcNodeBin.java
@@ -31,7 +31,7 @@ import java.util.Map;
  */
 public interface FullGcNodeBin {
 
-    String OAK_DOCUMENT_FULL_GC_BIN_ENABLED = "oak.document.fullGcBin.enabled";
+    String OAK_DOCUMENT_FULL_GC_BIN_ENABLED = "oak.documentstore.fullGCAuditLoggingEnabled";
 
     static FullGcNodeBin noBin(DocumentStore store) {
         return new FullGcNodeBin() {

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDocumentNodeStoreBuilderBase.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDocumentNodeStoreBuilderBase.java
@@ -172,7 +172,7 @@ public abstract class MongoDocumentNodeStoreBuilderBase<T extends MongoDocumentN
     public VersionGCSupport createVersionGCSupport() {
         DocumentStore store = getDocumentStore();
         if (store instanceof MongoDocumentStore) {
-            return new MongoVersionGCSupport((MongoDocumentStore) store);
+            return new MongoVersionGCSupport((MongoDocumentStore) store, isFullGCAuditLoggingEnabled());
         } else {
             return super.createVersionGCSupport();
         }

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDocumentStore.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDocumentStore.java
@@ -351,6 +351,9 @@ public class MongoDocumentStore implements DocumentStore {
 
         if (!readOnly) {
             ensureIndexes(db, status);
+            if (builder.isFullGCAuditLoggingEnabled()) {
+                ensureFullGcTTLIndex();
+            }
         }
 
         this.nodeLocks = new StripedNodeDocumentLocks();
@@ -466,10 +469,12 @@ public class MongoDocumentStore implements DocumentStore {
 
         // index on _modified for journal entries
         createIndex(journal, JournalEntry.MODIFIED, true, false, false);
+    }
 
+    private void ensureFullGcTTLIndex() {
         //TTL index for full GC bin documents to expire after 90 days
         //see https://issues.apache.org/jira/browse/OAK-11444
-        IndexOptions indexOptions = new IndexOptions().expireAfter(TimeUnit.DAYS.toSeconds(90), java.util.concurrent.TimeUnit.SECONDS);
+        IndexOptions indexOptions = new IndexOptions().expireAfter(TimeUnit.DAYS.toSeconds(90), TimeUnit.SECONDS);
         connection.getCollection(BIN_COLLECTION).createIndex(new org.bson.Document(MongoFullGcNodeBin.GC_COLLECTED_AT, 1), indexOptions);
     }
 

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoFullGcNodeBin.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoFullGcNodeBin.java
@@ -17,7 +17,6 @@
 package org.apache.jackrabbit.oak.plugins.document.mongo;
 
 import com.mongodb.BasicDBObject;
-import org.apache.jackrabbit.oak.commons.properties.SystemPropertySupplier;
 import org.apache.jackrabbit.oak.plugins.document.Collection;
 import org.apache.jackrabbit.oak.plugins.document.Document;
 import org.apache.jackrabbit.oak.plugins.document.DocumentStore;
@@ -25,7 +24,6 @@ import org.apache.jackrabbit.oak.plugins.document.FullGcNodeBin;
 import org.apache.jackrabbit.oak.plugins.document.NodeDocument;
 import org.apache.jackrabbit.oak.plugins.document.UpdateOp;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import java.time.Instant;
@@ -49,10 +47,15 @@ public class MongoFullGcNodeBin implements FullGcNodeBin {
     private static final Logger LOG = LoggerFactory.getLogger(MongoFullGcNodeBin.class);
     public static final String GC_COLLECTED_AT = "_gcCollectedAt";
     private final MongoDocumentStore mongoDocumentStore;
-    private boolean enabled = SystemPropertySupplier.create("oak.document.fullGcBin.enabled", false).get();
+    private boolean enabled;
 
     public MongoFullGcNodeBin(MongoDocumentStore ds) {
-        mongoDocumentStore = ds;
+        this(ds, Boolean.getBoolean(FullGcNodeBin.OAK_DOCUMENT_FULL_GC_BIN_ENABLED));
+    }
+
+    public MongoFullGcNodeBin(MongoDocumentStore store, boolean fullGcBinEnabled) {
+        mongoDocumentStore = store;
+        enabled = fullGcBinEnabled;
     }
 
     /**
@@ -100,15 +103,9 @@ public class MongoFullGcNodeBin implements FullGcNodeBin {
         return mongoDocumentStore.findAndUpdate(Collection.NODES, updateOpList);
     }
 
-    /**
-     * Saves the name of properties that will be removed  in the BIN collection
-     *
-     * @param orphanOrDeletedRemovalMap the keys of the documents to remove with the corresponding timestamps
-     * @return true if the documents were successfully added to the bin
-     */
-    private boolean addToBin(Map<String, Long> orphanOrDeletedRemovalMap) {
+    protected boolean addToBin(Map<String, Long> orphanOrDeletedRemovalMap) {
         if (!enabled) {
-            LOG.info("Bin is disabled, skip adding delete candidate documents to bin");
+            LOG.info("Bin is disabled, skipping adding delete candidate documents to bin");
             return true;
         }
         LOG.info("Adding {} delete candidate documents to bin", orphanOrDeletedRemovalMap.size());
@@ -124,15 +121,9 @@ public class MongoFullGcNodeBin implements FullGcNodeBin {
         return false;
     }
 
-    /**
-     * Saves the ID of documents that will be removed in the BIN collection
-     *
-     * @param updateOpList the update operation list for removing the documents
-     * @return true if the documents were successfully added to the bin
-     */
     private boolean addToBin(List<UpdateOp> updateOpList) {
         if (!enabled) {
-            LOG.info("Bin is disabled, skip adding removed properties to bin");
+            LOG.info("Bin is disabled, skipping adding removed properties to bin");
             return true;
         }
         LOG.info("Adding {} removed properties to bin", updateOpList.size());
@@ -145,12 +136,12 @@ public class MongoFullGcNodeBin implements FullGcNodeBin {
         return false;
     }
 
-    private boolean persist(List<BasicDBObject> inserts) {
+    protected boolean persist(List<BasicDBObject> inserts) {
         mongoDocumentStore.getBinCollection().insertMany(inserts);
         return true;
     }
 
-    private BasicDBObject toBasicDBObject(UpdateOp op) {
+    BasicDBObject toBasicDBObject(UpdateOp op) {
         BasicDBObject doc = new BasicDBObject();
         doc.put(Document.ID, "/bin/" + op.getId() + "-" + Instant.now().toEpochMilli());
         //copy removed properties to the new document

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoFullGcNodeBin.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoFullGcNodeBin.java
@@ -56,6 +56,7 @@ public class MongoFullGcNodeBin implements FullGcNodeBin {
     public MongoFullGcNodeBin(MongoDocumentStore store, boolean fullGcBinEnabled) {
         mongoDocumentStore = store;
         enabled = fullGcBinEnabled;
+        LOG.info("Full GC Bin is {}", enabled ? "enabled" : "disabled");
     }
 
     /**
@@ -160,5 +161,6 @@ public class MongoFullGcNodeBin implements FullGcNodeBin {
     @Override
     public void setEnabled(boolean value) {
         this.enabled = value;
+        LOG.info("Full GC Bin changed to {}", enabled ? "enabled" : "disabled");
     }
 }

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoFullGcNodeBin.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoFullGcNodeBin.java
@@ -56,7 +56,6 @@ public class MongoFullGcNodeBin implements FullGcNodeBin {
     public MongoFullGcNodeBin(MongoDocumentStore store, boolean fullGcBinEnabled) {
         mongoDocumentStore = store;
         enabled = fullGcBinEnabled;
-        LOG.info("Full GC Bin is {}", enabled ? "enabled" : "disabled");
     }
 
     /**

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoFullGcNodeBin.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoFullGcNodeBin.java
@@ -24,6 +24,7 @@ import org.apache.jackrabbit.oak.plugins.document.FullGcNodeBin;
 import org.apache.jackrabbit.oak.plugins.document.NodeDocument;
 import org.apache.jackrabbit.oak.plugins.document.UpdateOp;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import java.time.Instant;
@@ -46,6 +47,8 @@ import java.util.stream.Collectors;
 public class MongoFullGcNodeBin implements FullGcNodeBin {
     private static final Logger LOG = LoggerFactory.getLogger(MongoFullGcNodeBin.class);
     public static final String GC_COLLECTED_AT = "_gcCollectedAt";
+    private static final Logger LOG = LoggerFactory.getLogger(MongoFullGcNodeBin.class);
+
     private final MongoDocumentStore mongoDocumentStore;
     private boolean enabled;
 

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoFullGcNodeBin.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoFullGcNodeBin.java
@@ -45,7 +45,6 @@ import java.util.stream.Collectors;
  *  Each method delegates directly to DocumentStore
  */
 public class MongoFullGcNodeBin implements FullGcNodeBin {
-    private static final Logger LOG = LoggerFactory.getLogger(MongoFullGcNodeBin.class);
     public static final String GC_COLLECTED_AT = "_gcCollectedAt";
     private static final Logger LOG = LoggerFactory.getLogger(MongoFullGcNodeBin.class);
 
@@ -164,5 +163,9 @@ public class MongoFullGcNodeBin implements FullGcNodeBin {
     public void setEnabled(boolean value) {
         this.enabled = value;
         LOG.info("Full GC Bin changed to {}", enabled ? "enabled" : "disabled");
+    }
+
+    public boolean isEnabled() {
+        return enabled;
     }
 }

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoFullGcNodeBin.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoFullGcNodeBin.java
@@ -105,7 +105,7 @@ public class MongoFullGcNodeBin implements FullGcNodeBin {
         return mongoDocumentStore.findAndUpdate(Collection.NODES, updateOpList);
     }
 
-    protected boolean addToBin(Map<String, Long> orphanOrDeletedRemovalMap) {
+    private boolean addToBin(Map<String, Long> orphanOrDeletedRemovalMap) {
         if (!enabled) {
             LOG.info("Bin is disabled, skipping adding delete candidate documents to bin");
             return true;
@@ -138,12 +138,12 @@ public class MongoFullGcNodeBin implements FullGcNodeBin {
         return false;
     }
 
-    protected boolean persist(List<BasicDBObject> inserts) {
+    private boolean persist(List<BasicDBObject> inserts) {
         mongoDocumentStore.getBinCollection().insertMany(inserts);
         return true;
     }
 
-    BasicDBObject toBasicDBObject(UpdateOp op) {
+    private BasicDBObject toBasicDBObject(UpdateOp op) {
         BasicDBObject doc = new BasicDBObject();
         doc.put(Document.ID, "/bin/" + op.getId() + "-" + Instant.now().toEpochMilli());
         //copy removed properties to the new document

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoFullGcNodeBin.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoFullGcNodeBin.java
@@ -50,7 +50,7 @@ public class MongoFullGcNodeBin implements FullGcNodeBin {
     private boolean enabled;
 
     public MongoFullGcNodeBin(MongoDocumentStore ds) {
-        this(ds, Boolean.getBoolean(FullGcNodeBin.OAK_DOCUMENT_FULL_GC_BIN_ENABLED));
+        this(ds, false);
     }
 
     public MongoFullGcNodeBin(MongoDocumentStore store, boolean fullGcBinEnabled) {

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoVersionGCSupport.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoVersionGCSupport.java
@@ -101,7 +101,6 @@ public class MongoVersionGCSupport extends VersionGCSupport {
 
     /** the hint representing "_modified_1__id_1" - if that index exists, null otherwise */
     private final BasicDBObject modifiedIdHint;
-    private final MongoFullGcNodeBin fullGcNodeBin;
 
     /** timestamp of last time an explain of the 'getModifiedDocs' query was logged */
     private long lastExplainLogMs = -1;
@@ -114,7 +113,7 @@ public class MongoVersionGCSupport extends VersionGCSupport {
      */
     private final int batchSize = SystemPropertySupplier.create(
         "oak.mongo.queryDeletedDocsBatchSize", 1000).get();
-    private final boolean fullGcBinEnabled;
+    private final MongoFullGcNodeBin fullGcBin;
 
     public MongoVersionGCSupport(MongoDocumentStore store) {
         this(store, false);
@@ -137,7 +136,7 @@ public class MongoVersionGCSupport extends VersionGCSupport {
         } else {
             modifiedIdHint = null;
         }
-        this.fullGcBinEnabled = fullGcBinEnabled;
+        this.fullGcBin = new MongoFullGcNodeBin(store, fullGcBinEnabled);
     }
 
     @Override
@@ -491,7 +490,7 @@ public class MongoVersionGCSupport extends VersionGCSupport {
 
     @Override
     public FullGcNodeBin getFullGCBin() {
-        return new MongoFullGcNodeBin(store, fullGcBinEnabled);
+        return fullGcBin;
     }
 
     private static String getID(BasicDBObject document) {

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoVersionGCSupport.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoVersionGCSupport.java
@@ -29,6 +29,7 @@ import static java.util.Optional.ofNullable;
 import static com.mongodb.client.model.Filters.and;
 import static com.mongodb.client.model.Filters.lt;
 import static java.util.Collections.emptyList;
+import org.apache.jackrabbit.oak.commons.properties.SystemPropertySupplier;
 import static org.apache.jackrabbit.oak.plugins.document.Collection.NODES;
 import static org.apache.jackrabbit.oak.plugins.document.Document.ID;
 import org.apache.jackrabbit.oak.plugins.document.FullGcNodeBin;
@@ -111,8 +112,8 @@ public class MongoVersionGCSupport extends VersionGCSupport {
     /**
      * The batch size for the query of possibly deleted docs.
      */
-    private final int batchSize = Integer.getInteger(
-            "oak.mongo.queryDeletedDocsBatchSize", 1000);
+    private final int batchSize = SystemPropertySupplier.create(
+        "oak.mongo.queryDeletedDocsBatchSize", 1000).get();
     private final boolean fullGcBinEnabled;
 
     public MongoVersionGCSupport(MongoDocumentStore store) {

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoVersionGCSupport.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoVersionGCSupport.java
@@ -113,8 +113,13 @@ public class MongoVersionGCSupport extends VersionGCSupport {
      */
     private final int batchSize = Integer.getInteger(
             "oak.mongo.queryDeletedDocsBatchSize", 1000);
+    private final boolean fullGcBinEnabled;
 
     public MongoVersionGCSupport(MongoDocumentStore store) {
+        this(store, false);
+    }
+
+    public MongoVersionGCSupport(MongoDocumentStore store, boolean fullGcBinEnabled) {
         super(store);
         this.store = store;
         if(hasIndex(getNodeCollection(), SD_TYPE, SD_MAX_REV_TIME_IN_SECS)) {
@@ -131,7 +136,7 @@ public class MongoVersionGCSupport extends VersionGCSupport {
         } else {
             modifiedIdHint = null;
         }
-        fullGcNodeBin = new MongoFullGcNodeBin(store);
+        this.fullGcBinEnabled = fullGcBinEnabled;
     }
 
     @Override
@@ -485,7 +490,7 @@ public class MongoVersionGCSupport extends VersionGCSupport {
 
     @Override
     public FullGcNodeBin getFullGCBin() {
-        return fullGcNodeBin;
+        return new MongoFullGcNodeBin(store, fullGcBinEnabled);
     }
 
     private static String getID(BasicDBObject document) {

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/rdb/RDBDocumentNodeStoreBuilder.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/rdb/RDBDocumentNodeStoreBuilder.java
@@ -137,6 +137,18 @@ public class RDBDocumentNodeStoreBuilder
     }
 
     @Override
+    public boolean isFullGCAuditLoggingEnabled() {
+        // fullGC is non supported for RDB
+        return false;
+    }
+
+    @Override
+    public RDBDocumentNodeStoreBuilder setFullGCAuditLoggingEnabled(boolean b) {
+        // fullGC is non supported for RDB
+        return thisBuilder();
+    }
+
+    @Override
     public Set<String> getFullGCIncludePaths() {
         return of();
     }

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreServiceConfigurationTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreServiceConfigurationTest.java
@@ -104,6 +104,7 @@ public class DocumentNodeStoreServiceConfigurationTest {
         assertEquals(DEFAULT_EMBEDDED_VERIFICATION_ENABLED, config.embeddedVerificationEnabled());
         assertEquals(DocumentNodeStoreService.DEFAULT_FULL_GC_MAX_AGE, config.fullGcMaxAgeInSecs());
         assertEquals(CommitQueue.DEFAULT_SUSPEND_TIMEOUT, config.suspendTimeoutMillis());
+        assertFalse(config.fullGCAuditLoggingEnabled());
     }
 
     @Test
@@ -168,6 +169,13 @@ public class DocumentNodeStoreServiceConfigurationTest {
         addConfigurationEntry(preset, "fullGCBatchSize", batchSize);
         Configuration config = createConfiguration();
         assertEquals(batchSize, config.fullGCBatchSize());
+    }
+
+    @Test
+    public void fullGCAuditLoggingEnabled() throws Exception {
+        addConfigurationEntry(preset, "fullGCAuditLoggingEnabled", true);
+        Configuration config = createConfiguration();
+        assertTrue(config.fullGCAuditLoggingEnabled());
     }
 
     @Test

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDocumentNodeStoreBuilderTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDocumentNodeStoreBuilderTest.java
@@ -132,4 +132,10 @@ public class MongoDocumentNodeStoreBuilderTest {
         final int fullGcModeNone = 0;
         assertEquals(builder.getFullGCMode(), fullGcModeNone);
     }
+
+    @Test
+    public void isFullGCAuditLoggingEnabled() {
+        MongoDocumentNodeStoreBuilder builder = new MongoDocumentNodeStoreBuilder();
+        assertFalse(builder.isFullGCAuditLoggingEnabled());
+    }
 }

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoFullGcNodeBinTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoFullGcNodeBinTest.java
@@ -80,7 +80,6 @@ public class MongoFullGcNodeBinTest {
     @After
     public void tearDown() {
         Mockito.reset(documentStore, mockBinCollection);
-        System.clearProperty(FullGcNodeBin.OAK_DOCUMENT_FULL_GC_BIN_ENABLED);
     }
 
     @Test
@@ -92,19 +91,6 @@ public class MongoFullGcNodeBinTest {
     public void enableWithConstructor() {
         assertTrue(new MongoFullGcNodeBin(this.documentStore, true).isEnabled());
     }
-
-    @Test
-    public void enableWithSystemProperty() {
-        System.setProperty(FullGcNodeBin.OAK_DOCUMENT_FULL_GC_BIN_ENABLED, "true");
-        assertTrue(new MongoFullGcNodeBin(this.documentStore).isEnabled());
-    }
-
-    @Test
-    public void enableWithConstructorHasPrecedence() {
-        System.setProperty(FullGcNodeBin.OAK_DOCUMENT_FULL_GC_BIN_ENABLED, "false");
-        assertTrue(new MongoFullGcNodeBin(this.documentStore, true).isEnabled());
-    }
-
 
     @Test
     public void remove() {

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoFullGcNodeBinTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoFullGcNodeBinTest.java
@@ -21,8 +21,10 @@ import com.mongodb.BasicDBObject;
 import com.mongodb.client.MongoCollection;
 import org.apache.jackrabbit.oak.plugins.document.Collection;
 import org.apache.jackrabbit.oak.plugins.document.Document;
+import org.apache.jackrabbit.oak.plugins.document.FullGcNodeBin;
 import org.apache.jackrabbit.oak.plugins.document.NodeDocument;
 import org.apache.jackrabbit.oak.plugins.document.UpdateOp;
+import org.junit.After;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -53,7 +55,7 @@ public class MongoFullGcNodeBinTest {
     @Mock
     MongoDocumentStore documentStore;
 
-    @InjectMocks
+
     MongoFullGcNodeBin fullGcBin;
 
     @Mock MongoCollection<BasicDBObject> mockBinCollection;
@@ -62,6 +64,7 @@ public class MongoFullGcNodeBinTest {
     @Before
     public void setUp() throws Exception {
         MockitoAnnotations.openMocks(this);
+        fullGcBin = new MongoFullGcNodeBin(documentStore, true);
         when(documentStore.remove(eq(Collection.NODES), anyMap())).thenAnswer(invocation -> {
             Map<String, Long> map = invocation.getArgument(1);
             return map.size();
@@ -72,9 +75,36 @@ public class MongoFullGcNodeBinTest {
         });
 
         when(documentStore.getBinCollection()).thenReturn(mockBinCollection);
-
-        fullGcBin.setEnabled(true);
     }
+
+    @After
+    public void tearDown() {
+        Mockito.reset(documentStore, mockBinCollection);
+        System.clearProperty(FullGcNodeBin.OAK_DOCUMENT_FULL_GC_BIN_ENABLED);
+    }
+
+    @Test
+    public void defaultDisabled() {
+        assertFalse(new MongoFullGcNodeBin(this.documentStore).isEnabled());
+    }
+
+    @Test
+    public void enableWithConstructor() {
+        assertTrue(new MongoFullGcNodeBin(this.documentStore, true).isEnabled());
+    }
+
+    @Test
+    public void enableWithSystemProperty() {
+        System.setProperty(FullGcNodeBin.OAK_DOCUMENT_FULL_GC_BIN_ENABLED, "true");
+        assertTrue(new MongoFullGcNodeBin(this.documentStore).isEnabled());
+    }
+
+    @Test
+    public void enableWithConstructorHasPrecedence() {
+        System.setProperty(FullGcNodeBin.OAK_DOCUMENT_FULL_GC_BIN_ENABLED, "false");
+        assertTrue(new MongoFullGcNodeBin(this.documentStore, true).isEnabled());
+    }
+
 
     @Test
     public void remove() {

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/rdb/RDBDocumentNodeStoreBuilderTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/rdb/RDBDocumentNodeStoreBuilderTest.java
@@ -121,4 +121,11 @@ public class RDBDocumentNodeStoreBuilderTest {
         builder.setFullGcMaxAgeMillis(30 * 24 * 60 * 60 * 1000L);
         assertEquals(0, builder.getFullGcMaxAgeMillis());
     }
+
+    @Test
+    public void fullGcAuditLoggingEnabled() {
+        RDBDocumentNodeStoreBuilder builder = new RDBDocumentNodeStoreBuilder();
+        builder.setFullGCAuditLoggingEnabled(true);
+        assertFalse(builder.isFullGCAuditLoggingEnabled());
+    }
 }


### PR DESCRIPTION
Add OSGi configuration to enable/disable full GC audit bin (default disabled)
Add `-fullGCAuditLoggingEnabled` option for oak-run (default disabled)